### PR TITLE
Add GitHub Actions CI deployment for ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  release:
+    types: ['published']
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:alpine
 WORKDIR /app
-COPY package*.json /app
+COPY package*.json /app/
 RUN npm install
-COPY index.js /app
+COPY index.js /app/
 
 ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
Includes improvements to the Docker process by fixing an oversight in the Dockerfile and adding a GitHub Action to push images to GitHub Container Repository (ghcr.io) whenever a new release is created. You can see my repository for an [example run](https://github.com/ndm13/BinBot-discord/actions/runs/16405176701) and the [resulting package](https://github.com/ndm13/BinBot-discord/pkgs/container/binbot-discord/465926648?tag=0.0.0-docker-ci-test) for [this test release](https://github.com/ndm13/BinBot-discord/releases/tag/0.0.0-docker-ci-test).